### PR TITLE
Rubynltm: Fix OpenSSL Ruby 3.4 compat

### DIFF
--- a/lib/net/ntlm.rb
+++ b/lib/net/ntlm.rb
@@ -42,6 +42,7 @@ require 'openssl/digest'
 require 'socket'
 
 # Load Order is important here
+require 'net/ntlm/crypto'
 require 'net/ntlm/exceptions'
 require 'net/ntlm/field'
 require 'net/ntlm/int16_le'
@@ -123,12 +124,12 @@ module Net
       end
 
       def apply_des(plain, keys)
-        dec = OpenSSL::Cipher.new("des-cbc")
-        dec.padding = 0
-        keys.map {|k|
+        keys.map do |k|
+          dec = Crypto::DES.new
+          dec.padding = 0
           dec.key = k
           dec.encrypt.update(plain) + dec.final
-        }
+        end
       end
 
       # Generates a Lan Manager Hash
@@ -146,7 +147,7 @@ module Net
         unless opt[:unicode]
           pwd = EncodeUtil.encode_utf16le(pwd)
         end
-        OpenSSL::Digest::MD4.digest pwd
+        Crypto::MD4.digest pwd
       end
 
       # Generate a NTLMv2 Hash

--- a/lib/net/ntlm/client/session.rb
+++ b/lib/net/ntlm/client/session.rb
@@ -36,8 +36,7 @@ module Net
         t3 = Message::Type3.create type3_opts
         if negotiate_key_exchange?
           t3.enable(:session_key)
-          rc4 = OpenSSL::Cipher.new("rc4")
-          rc4.encrypt
+          rc4 = NTLM::Crypto::RC4.new
           rc4.key = user_session_key
           sk = rc4.update exported_session_key
           sk << rc4.final
@@ -50,7 +49,7 @@ module Net
         @exported_session_key ||=
           begin
             if negotiate_key_exchange?
-              OpenSSL::Cipher.new("rc4").random_key
+              NTLM::Crypto::RC4.new.random_key
             else
               user_session_key
             end
@@ -125,8 +124,7 @@ module Net
       def client_cipher
         @client_cipher ||=
           begin
-            rc4 = OpenSSL::Cipher.new("rc4")
-            rc4.encrypt
+            rc4 = NTLM::Crypto::RC4.new
             rc4.key = client_seal_key
             rc4
           end
@@ -135,8 +133,7 @@ module Net
       def server_cipher
         @server_cipher ||=
           begin
-            rc4 = OpenSSL::Cipher.new("rc4")
-            rc4.decrypt
+            rc4 = NTLM::Crypto::RC4.new
             rc4.key = server_seal_key
             rc4
           end

--- a/lib/net/ntlm/crypto.rb
+++ b/lib/net/ntlm/crypto.rb
@@ -1,0 +1,3 @@
+require 'net/ntlm/crypto/md4'
+require 'net/ntlm/crypto/rc4'
+require 'net/ntlm/crypto/des'

--- a/lib/net/ntlm/crypto/des.rb
+++ b/lib/net/ntlm/crypto/des.rb
@@ -1,0 +1,286 @@
+# Pure-Ruby DES-CBC cipher with an OpenSSL::Cipher-compatible interface.
+# Required because OpenSSL 3.x disables DES by default.
+#
+# NTLM uses DES-CBC (with a zero IV and no padding) to compute LM hashes
+# and the legacy NTLM response.  Each plaintext is exactly one 8-byte DES
+# block, so CBC with a zero IV is equivalent to ECB for these operations.
+#
+# Reference: FIPS 46-3 / ANSI X3.92
+
+module Net
+  module NTLM
+    module Crypto
+      class DES
+        # ── DES lookup tables (all indices are 1-based per the FIPS spec) ──
+
+        # PC-1: 64-bit key → 56-bit C||D halves
+        PC1 = [
+          57, 49, 41, 33, 25, 17,  9,
+           1, 58, 50, 42, 34, 26, 18,
+          10,  2, 59, 51, 43, 35, 27,
+          19, 11,  3, 60, 52, 44, 36,
+          63, 55, 47, 39, 31, 23, 15,
+           7, 62, 54, 46, 38, 30, 22,
+          14,  6, 61, 53, 45, 37, 29,
+          21, 13,  5, 28, 20, 12,  4
+        ].freeze
+
+        # PC-2: 56-bit C||D → 48-bit subkey
+        PC2 = [
+          14, 17, 11, 24,  1,  5,
+           3, 28, 15,  6, 21, 10,
+          23, 19, 12,  4, 26,  8,
+          16,  7, 27, 20, 13,  2,
+          41, 52, 31, 37, 47, 55,
+          30, 40, 51, 45, 33, 48,
+          44, 49, 39, 56, 34, 53,
+          46, 42, 50, 36, 29, 32
+        ].freeze
+
+        # Initial Permutation
+        IP = [
+          58, 50, 42, 34, 26, 18, 10,  2,
+          60, 52, 44, 36, 28, 20, 12,  4,
+          62, 54, 46, 38, 30, 22, 14,  6,
+          64, 56, 48, 40, 32, 24, 16,  8,
+          57, 49, 41, 33, 25, 17,  9,  1,
+          59, 51, 43, 35, 27, 19, 11,  3,
+          61, 53, 45, 37, 29, 21, 13,  5,
+          63, 55, 47, 39, 31, 23, 15,  7
+        ].freeze
+
+        # Final Permutation (IP⁻¹)
+        FP = [
+          40,  8, 48, 16, 56, 24, 64, 32,
+          39,  7, 47, 15, 55, 23, 63, 31,
+          38,  6, 46, 14, 54, 22, 62, 30,
+          37,  5, 45, 13, 53, 21, 61, 29,
+          36,  4, 44, 12, 52, 20, 60, 28,
+          35,  3, 43, 11, 51, 19, 59, 27,
+          34,  2, 42, 10, 50, 18, 58, 26,
+          33,  1, 41,  9, 49, 17, 57, 25
+        ].freeze
+
+        # Expansion E: 32-bit R half → 48 bits
+        E_TABLE = [
+          32,  1,  2,  3,  4,  5,
+           4,  5,  6,  7,  8,  9,
+           8,  9, 10, 11, 12, 13,
+          12, 13, 14, 15, 16, 17,
+          16, 17, 18, 19, 20, 21,
+          20, 21, 22, 23, 24, 25,
+          24, 25, 26, 27, 28, 29,
+          28, 29, 30, 31, 32,  1
+        ].freeze
+
+        # P permutation applied after S-box substitution
+        P_TABLE = [
+          16,  7, 20, 21,
+          29, 12, 28, 17,
+           1, 15, 23, 26,
+           5, 18, 31, 10,
+           2,  8, 24, 14,
+          32, 27,  3,  9,
+          19, 13, 30,  6,
+          22, 11,  4, 25
+        ].freeze
+
+        # S-boxes S1..S8 (indexed [box][row][col])
+        SBOX = [
+          [ # S1
+            [14,  4, 13,  1,  2, 15, 11,  8,  3, 10,  6, 12,  5,  9,  0,  7],
+            [ 0, 15,  7,  4, 14,  2, 13,  1, 10,  6, 12, 11,  9,  5,  3,  8],
+            [ 4,  1, 14,  8, 13,  6,  2, 11, 15, 12,  9,  7,  3, 10,  5,  0],
+            [15, 12,  8,  2,  4,  9,  1,  7,  5, 11,  3, 14, 10,  0,  6, 13]
+          ],
+          [ # S2
+            [15,  1,  8, 14,  6, 11,  3,  4,  9,  7,  2, 13, 12,  0,  5, 10],
+            [ 3, 13,  4,  7, 15,  2,  8, 14, 12,  0,  1, 10,  6,  9, 11,  5],
+            [ 0, 14,  7, 11, 10,  4, 13,  1,  5,  8, 12,  6,  9,  3,  2, 15],
+            [13,  8, 10,  1,  3, 15,  4,  2, 11,  6,  7, 12,  0,  5, 14,  9]
+          ],
+          [ # S3
+            [10,  0,  9, 14,  6,  3, 15,  5,  1, 13, 12,  7, 11,  4,  2,  8],
+            [13,  7,  0,  9,  3,  4,  6, 10,  2,  8,  5, 14, 12, 11, 15,  1],
+            [13,  6,  4,  9,  8, 15,  3,  0, 11,  1,  2, 12,  5, 10, 14,  7],
+            [ 1, 10, 13,  0,  6,  9,  8,  7,  4, 15, 14,  3, 11,  5,  2, 12]
+          ],
+          [ # S4
+            [ 7, 13, 14,  3,  0,  6,  9, 10,  1,  2,  8,  5, 11, 12,  4, 15],
+            [13,  8, 11,  5,  6, 15,  0,  3,  4,  7,  2, 12,  1, 10, 14,  9],
+            [10,  6,  9,  0, 12, 11,  7, 13, 15,  1,  3, 14,  5,  2,  8,  4],
+            [ 3, 15,  0,  6, 10,  1, 13,  8,  9,  4,  5, 11, 12,  7,  2, 14]
+          ],
+          [ # S5
+            [ 2, 12,  4,  1,  7, 10, 11,  6,  8,  5,  3, 15, 13,  0, 14,  9],
+            [14, 11,  2, 12,  4,  7, 13,  1,  5,  0, 15, 10,  3,  9,  8,  6],
+            [ 4,  2,  1, 11, 10, 13,  7,  8, 15,  9, 12,  5,  6,  3,  0, 14],
+            [11,  8, 12,  7,  1, 14,  2, 13,  6, 15,  0,  9, 10,  4,  5,  3]
+          ],
+          [ # S6
+            [12,  1, 10, 15,  9,  2,  6,  8,  0, 13,  3,  4, 14,  7,  5, 11],
+            [10, 15,  4,  2,  7, 12,  9,  5,  6,  1, 13, 14,  0, 11,  3,  8],
+            [ 9, 14, 15,  5,  2,  8, 12,  3,  7,  0,  4, 10,  1, 13, 11,  6],
+            [ 4,  3,  2, 12,  9,  5, 15, 10, 11, 14,  1,  7,  6,  0,  8, 13]
+          ],
+          [ # S7
+            [ 4, 11,  2, 14, 15,  0,  8, 13,  3, 12,  9,  7,  5, 10,  6,  1],
+            [13,  0, 11,  7,  4,  9,  1, 10, 14,  3,  5, 12,  2, 15,  8,  6],
+            [ 1,  4, 11, 13, 12,  3,  7, 14, 10, 15,  6,  8,  0,  5,  9,  2],
+            [ 6, 11, 13,  8,  1,  4, 10,  7,  9,  5,  0, 15, 14,  2,  3, 12]
+          ],
+          [ # S8
+            [13,  2,  8,  4,  6, 15, 11,  1, 10,  9,  3, 14,  5,  0, 12,  7],
+            [ 1, 15, 13,  8, 10,  3,  7,  4, 12,  5,  6, 11,  0, 14,  9,  2],
+            [ 7, 11,  4,  1,  9, 12, 14,  2,  0,  6, 10, 13, 15,  3,  5,  8],
+            [ 2,  1, 14,  7,  4, 10,  8, 13, 15, 12,  9,  0,  3,  5,  6, 11]
+          ]
+        ].freeze
+
+        # Left-rotation amounts for each of the 16 key schedule rounds
+        ROTATIONS = [1, 1, 2, 2, 2, 2, 2, 2, 1, 2, 2, 2, 2, 2, 2, 1].freeze
+
+        # ── Public interface (OpenSSL::Cipher compatible) ──
+
+        attr_writer :padding
+
+        def initialize
+          @encrypt = true
+          @padding = 1
+          @iv = "\x00" * 8
+          @subkeys = nil
+        end
+
+        def key=(k)
+          @subkeys = generate_subkeys(k.b)
+          self
+        end
+
+        def encrypt
+          @encrypt = true
+          self
+        end
+
+        def decrypt
+          @encrypt = false
+          self
+        end
+
+        # Processes +data+ in 8-byte CBC blocks and returns the result.
+        # +data+ must be a multiple of 8 bytes (padding = 0 is NTLM's usage).
+        def update(data)
+          result = ''.b
+          prev   = @iv.b.bytes
+
+          data.b.bytes.each_slice(8) do |block|
+            if @encrypt
+              input = block.zip(prev).map { |a, b| a ^ b }
+              enc   = des_ecb_encrypt(input.pack('C*'))
+              result << enc
+              prev = enc.bytes
+            else
+              dec  = des_ecb_decrypt(block.pack('C*'))
+              xord = dec.bytes.zip(prev).map { |a, b| a ^ b }
+              result << xord.pack('C*')
+              prev = block
+            end
+          end
+
+          result
+        end
+
+        def final
+          ''.b
+        end
+
+        private
+
+        # ── Bit-level helpers ──
+
+        # Convert a byte string to an array of bits (MSB first per byte).
+        def to_bits(data)
+          data.bytes.flat_map { |byte| 8.times.map { |i| (byte >> (7 - i)) & 1 } }
+        end
+
+        # Convert an array of bits back to a byte string.
+        def from_bits(bits)
+          bits.each_slice(8).map { |b| b.each_with_index.reduce(0) { |acc, (bit, i)| acc | (bit << (7 - i)) } }.pack('C*')
+        end
+
+        # Apply a permutation table (1-based indices) to a bit array.
+        def permute(bits, table)
+          table.map { |i| bits[i - 1] }
+        end
+
+        def rotate_left(bits, n)
+          bits[n..] + bits[0, n]
+        end
+
+        # ── Key schedule ──
+
+        def generate_subkeys(key)
+          cd = permute(to_bits(key), PC1)  # 56 bits
+          c  = cd[0, 28]
+          d  = cd[28, 28]
+          ROTATIONS.map do |r|
+            c = rotate_left(c, r)
+            d = rotate_left(d, r)
+            permute(c + d, PC2)  # 48-bit subkey
+          end
+        end
+
+        # ── Feistel function f(R, K) ──
+
+        def feistel(r_bits, subkey)
+          # 1. Expand R from 32 to 48 bits
+          er = permute(r_bits, E_TABLE)
+
+          # 2. XOR with subkey
+          xored = er.zip(subkey).map { |a, b| a ^ b }
+
+          # 3. S-box substitution (8 × 6-bit groups → 8 × 4-bit groups = 32 bits)
+          sout = 8.times.flat_map do |i|
+            grp = xored[i * 6, 6]
+            row = (grp[0] << 1) | grp[5]
+            col = (grp[1] << 3) | (grp[2] << 2) | (grp[3] << 1) | grp[4]
+            val = SBOX[i][row][col]
+            [(val >> 3) & 1, (val >> 2) & 1, (val >> 1) & 1, val & 1]
+          end
+
+          # 4. P permutation
+          permute(sout, P_TABLE)
+        end
+
+        # ── Single-block DES (ECB) operations ──
+
+        def des_ecb_encrypt(block)
+          bits = permute(to_bits(block), IP)
+          l = bits[0, 32]
+          r = bits[32, 32]
+
+          16.times do |i|
+            new_r = l.zip(feistel(r, @subkeys[i])).map { |a, b| a ^ b }
+            l = r
+            r = new_r
+          end
+
+          from_bits(permute(r + l, FP))
+        end
+
+        def des_ecb_decrypt(block)
+          bits = permute(to_bits(block), IP)
+          l = bits[0, 32]
+          r = bits[32, 32]
+
+          15.downto(0) do |i|
+            new_r = l.zip(feistel(r, @subkeys[i])).map { |a, b| a ^ b }
+            l = r
+            r = new_r
+          end
+
+          from_bits(permute(r + l, FP))
+        end
+      end
+    end
+  end
+end

--- a/lib/net/ntlm/crypto/md4.rb
+++ b/lib/net/ntlm/crypto/md4.rb
@@ -1,0 +1,84 @@
+# Pure-Ruby MD4 digest implementation (RFC 1320).
+# Required because OpenSSL 3.x disables MD4 (legacy provider) by default,
+# and Ruby 3.4 ships with openssl gem linked against OpenSSL 3.x.
+#
+# NTLM requires MD4 for computing the NT hash from a password.
+
+module Net
+  module NTLM
+    module Crypto
+      module MD4
+        MASK = 0xffffffff
+
+        module_function
+
+        def digest(data)
+          # Build a fresh binary (ASCII-8BIT) buffer to avoid encoding conflicts.
+          # encode_utf16le returns strings whose encoding tag is UTF-8 even though
+          # the bytes are UTF-16LE; using an explicit binary buffer ensures all
+          # concatenation stays ASCII-8BIT regardless of the caller's encoding.
+          msg = ::String.new(encoding: Encoding::BINARY)
+          msg << data.b
+
+          # Initialize state (little-endian constants)
+          a = 0x67452301
+          b = 0xefcdab89
+          c = 0x98badcfe
+          d = 0x10325476
+
+          # Pad message: append 0x80, zeros, then 64-bit LE bit-length
+          bit_len = msg.bytesize * 8
+          msg << 0x80.chr(Encoding::BINARY)
+          msg << 0x00.chr(Encoding::BINARY) while msg.bytesize % 64 != 56
+          msg << [bit_len & MASK, bit_len >> 32].pack('VV')
+
+          # Process each 512-bit (64-byte) block
+          msg.unpack('V*').each_slice(16) do |x|
+            aa, bb, cc, dd = a, b, c, d
+
+            # Round 1 — F(b,c,d) = (b & c) | (~b & d), const = 0
+            r1_shifts = [3, 7, 11, 19]
+            16.times do |i|
+              s = r1_shifts[i % 4]
+              t = (a + f(b, c, d) + x[i]) & MASK
+              a, b, c, d = d, left_rotate(t, s), b, c
+            end
+
+            # Round 2 — G(b,c,d) = (b & c) | (b & d) | (c & d), const = 0x5a827999
+            r2_order = [0, 4, 8, 12, 1, 5, 9, 13, 2, 6, 10, 14, 3, 7, 11, 15]
+            r2_shifts = [3, 5, 9, 13]
+            16.times do |i|
+              s = r2_shifts[i % 4]
+              t = (a + g(b, c, d) + x[r2_order[i]] + 0x5a827999) & MASK
+              a, b, c, d = d, left_rotate(t, s), b, c
+            end
+
+            # Round 3 — H(b,c,d) = b ^ c ^ d, const = 0x6ed9eba1
+            r3_order = [0, 8, 4, 12, 2, 10, 6, 14, 1, 9, 5, 13, 3, 11, 7, 15]
+            r3_shifts = [3, 9, 11, 15]
+            16.times do |i|
+              s = r3_shifts[i % 4]
+              t = (a + h(b, c, d) + x[r3_order[i]] + 0x6ed9eba1) & MASK
+              a, b, c, d = d, left_rotate(t, s), b, c
+            end
+
+            a = (a + aa) & MASK
+            b = (b + bb) & MASK
+            c = (c + cc) & MASK
+            d = (d + dd) & MASK
+          end
+
+          [a, b, c, d].pack('V4')
+        end
+
+        def f(b, c, d); (b & c) | (~b & d); end
+        def g(b, c, d); (b & c) | (b & d) | (c & d); end
+        def h(b, c, d); b ^ c ^ d; end
+
+        def left_rotate(x, n)
+          ((x << n) | (x >> (32 - n))) & MASK
+        end
+      end
+    end
+  end
+end

--- a/lib/net/ntlm/crypto/rc4.rb
+++ b/lib/net/ntlm/crypto/rc4.rb
@@ -1,0 +1,61 @@
+# Pure-Ruby RC4 (ARCFOUR) stream cipher with an OpenSSL::Cipher-compatible interface.
+# Required because OpenSSL 3.x disables RC4 by default.
+#
+# NTLM uses RC4 for session key exchange in the AUTHENTICATE message.
+
+require 'securerandom'
+
+module Net
+  module NTLM
+    module Crypto
+      class RC4
+        def initialize
+          @s = (0..255).to_a
+          @i = 0
+          @j = 0
+          @key = nil
+        end
+
+        # Sets the cipher key and initialises the KSA (Key Scheduling Algorithm).
+        def key=(k)
+          @key = k.b
+          key_bytes = @key.bytes
+          key_len   = key_bytes.length
+          @s = (0..255).to_a
+          j = 0
+          256.times do |i|
+            j = (j + @s[i] + key_bytes[i % key_len]) % 256
+            @s[i], @s[j] = @s[j], @s[i]
+          end
+          @i = @j = 0
+          self
+        end
+
+        # Generates a random 16-byte key, sets it, and returns the raw key bytes.
+        # Matches the OpenSSL::Cipher#random_key interface.
+        def random_key
+          k = SecureRandom.random_bytes(16)
+          self.key = k
+          k
+        end
+
+        # No-op — RC4 is symmetric; encrypt/decrypt are the same operation.
+        def encrypt; self; end
+        def decrypt; self; end
+
+        def update(data)
+          data.b.bytes.map do |byte|
+            @i = (@i + 1) % 256
+            @j = (@j + @s[@i]) % 256
+            @s[@i], @s[@j] = @s[@j], @s[@i]
+            byte ^ @s[(@s[@i] + @s[@j]) % 256]
+          end.pack('C*')
+        end
+
+        def final
+          ''.b
+        end
+      end
+    end
+  end
+end

--- a/lib/net/ntlm/version.rb
+++ b/lib/net/ntlm/version.rb
@@ -4,7 +4,7 @@ module Net
     module VERSION
       MAJOR = 0
       MINOR = 6
-      TINY  = 2
+      TINY  = 3
       STRING = [MAJOR, MINOR, TINY].join('.')
     end
   end

--- a/rubyntlm.gemspec
+++ b/rubyntlm.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.test_files    = s.files.grep(%r{^(test|spec|features)/})
   s.require_paths = ["lib"]
 
-  s.required_ruby_version = '>= 1.8.7'
+  s.required_ruby_version = '>= 2.5'
 
   s.license = 'MIT'
 


### PR DESCRIPTION
#### What does this PR do? (required)

OpenSSL 3.x (shipped with Ruby 3.4) disables legacy crypto primitives by default — MD4, DES-CBC, and RC4 are all unavailable unless the OpenSSL legacy provider is explicitly loaded. NTLM requires all three, so the gem breaks entirely on Ruby 3.4.

This PR replaces each broken OpenSSL call with a self-contained pure-Ruby implementation, adding zero new gem dependencies:

- `lib/net/ntlm/crypto/md4.rb` — RFC 1320 MD4 (replaces `OpenSSL::Digest::MD4` at `ntlm.rb:149`)
- `lib/net/ntlm/crypto/rc4.rb` — RC4 stream cipher with OpenSSL-compatible interface (replaces `OpenSSL::Cipher.new("rc4")` at `client/session.rb:39,53,128,138`)
- `lib/net/ntlm/crypto/des.rb` — DES-CBC (replaces `OpenSSL::Cipher.new("des-cbc")` at `ntlm.rb:126`)

Version bumped `0.6.2 → 0.6.3`, `required_ruby_version` updated to `>= 2.5`. All 741 existing tests pass unchanged, including the full LM/NTLM/NTLMv2 hash test vectors.

Note: Viewpoint depends on this gem for Exchange NTLM authentication.

#### Link to Basecamp to-do, Trello card, New Relic or Honeybadger (required)

https://linear.app/wealthbox-crm/issue/SRE-53/rubyntlm-openssl-3x-legacy-crypto

#### What platforms should be included in QA?
- [ ] Desktop web
- [ ] Mobile web
- [ ] iOS native app
- [ ] Android native app
- [ ] API
- [x] N/A

#### QA steps
- [ ] Ensure Ruby 3.4 (or 3.x with OpenSSL 3.x) is available
- [ ] `bundle exec rspec` — all 741 examples should pass
- [ ] Verify Viewpoint/Exchange NTLM auth still works end-to-end in the host app

#### Screenshots (if appropriate)
N/A